### PR TITLE
OAuth Fixes

### DIFF
--- a/multinet/auth/google.py
+++ b/multinet/auth/google.py
@@ -26,7 +26,7 @@ from multinet.user import (
 from multinet.auth import MULTINET_COOKIE
 from multinet.auth.types import GoogleUserInfo, User
 
-from typing import Dict
+from typing import Dict, Optional
 
 
 CLIENT_ID = os.getenv("GOOGLE_CLIENT_ID")
@@ -98,7 +98,7 @@ def init_oauth(app: Flask) -> None:
 @bp.route("/login")
 @use_kwargs({"return_url": fields.Str(location="query")})
 @swag_from("swagger/google/login.yaml")
-def login(return_url: str = None) -> ResponseWrapper:
+def login(return_url: Optional[str] = None) -> ResponseWrapper:
     """Redirect the user to Google to authorize this app."""
     google = oauth.create_client("google")
 

--- a/multinet/auth/google.py
+++ b/multinet/auth/google.py
@@ -38,8 +38,6 @@ GOOGLE_USER_INFO_URL = "oauth2/v3/userinfo"
 bp = Blueprint("google", "google")
 oauth = OAuth()
 
-states_to_return_urls = {}
-
 
 def parse_id_token(token: str) -> GoogleUserInfo:
     """Parse the base64 encoded id token."""
@@ -104,7 +102,7 @@ def login(return_url: str) -> ResponseWrapper:
     url = state_and_url["url"]
 
     # Used to return user to return_url
-    states_to_return_urls[state] = return_url
+    session["return_url"] = return_url
 
     # So the flask session knows about the state
     google.save_authorize_data(
@@ -137,8 +135,7 @@ def authorized(state: str, code: str) -> ResponseWrapper:
     user = set_user_cookie(user)
     cookie = get_user_cookie(user)
 
-    # Pop return_url using state as key
-    return_url = states_to_return_urls.pop(state)
+    return_url = session.pop("return_url")
     resp = make_response(redirect(ensure_external_url(return_url)))
     session[MULTINET_COOKIE] = cookie
 

--- a/multinet/auth/google.py
+++ b/multinet/auth/google.py
@@ -45,7 +45,7 @@ def default_return_url() -> str:
 
     Must be done as a function, so the app context is available.
     """
-    return url_for("user.user_info")
+    return url_for("user.user_info", _external=True)
 
 
 def parse_id_token(token: str) -> GoogleUserInfo:

--- a/multinet/auth/types.py
+++ b/multinet/auth/types.py
@@ -33,9 +33,10 @@ class GoogleUserInfo:
 
     azp: str
     aud: str
-    hd: str
     at_hash: str
     nonce: str
+
+    hd: Optional[str] = None
 
 
 @dataclass


### PR DESCRIPTION
* Adds a default `return_url` for the login endpoint
* Replaces the use of `states_to_return_url` (which is __not__ safe across multiple workers) with the use of the `session` object (which is). 
* Make the `hd` field of `GoogleUserInfo` optional, as only some accounts have that field.