### PR TITLE
Make Arango root password configurable at provisioning time

### DIFF
--- a/devops/README.md
+++ b/devops/README.md
@@ -3,13 +3,15 @@
 The `arangodb.yml` Ansible playbook in this directory installs and configures
 ArangoDB on an Ubuntu server. It does the following:
 - installs ArangoDB
-- sets a default password (this will be configurable in the future; see
-  https://github.com/multinet-app/multinet-server/issues/348)
+- sets a password on the root account
 - configures it to listen on all interfaces
 - starts the service
+
+To set the root account password, you can either supply it on the command line
+(see below) or just let Ansible prompt you for it.
 
 To run it via ssh, run a command such as the following:
 
 ```
-ansible-playbook -i <target-hostname>, arangodb.yml --ssh-extra-args="-i <identify.pem>"
+ansible-playbook arangodb.yml -i <target-hostname>, --ssh-extra-args="-i <identity.pem>" -e arangodb_root_password=<password>
 ```

--- a/devops/arangodb.yml
+++ b/devops/arangodb.yml
@@ -4,7 +4,10 @@
 
   vars:
     ansible_python_interpreter: /usr/bin/python3
-    arangodb_password: "letmein"
+
+  vars_prompt:
+    - name: arangodb_root_password
+      prompt: "Password for ArangoDB root account"
 
   tasks:
     # https://www.arangodb.com/download-major/ubuntu/
@@ -36,7 +39,7 @@
       become: true
 
     - name: Overwrite the default arangodb password
-      shell: ARANGODB_DEFAULT_ROOT_PASSWORD={{ arangodb_password }} arango-secure-installation
+      shell: ARANGODB_DEFAULT_ROOT_PASSWORD={{ arangodb_root_password }} arango-secure-installation
       become: true
 
     - name: Enable arangodb to listen on all interfaces


### PR DESCRIPTION
Closes #348

I am not planning to actually use this playbook to update the ArangoDB password now; I'll do that manually. But this includes the appropriate fix in our automated deployment script.