### PR TITLE
Enable cross-origin credential transfer to login API

### DIFF
--- a/.env.default
+++ b/.env.default
@@ -14,8 +14,9 @@ GOOGLE_CLIENT_SECRET=
 # Will be set automatically by the server
 FLASK_SECRET_KEY=
 
-# Comma separated list of domains.
-CORS_HOSTS=http://localhost:8080
+# Comma separated list of domains that will be allowed to send cookies to the
+# server.
+ALLOWED_ORIGINS=http://localhost:8080
 
 ARANGO_HOST=localhost
 ARANGO_PORT=8529

--- a/.env.default
+++ b/.env.default
@@ -15,7 +15,7 @@ GOOGLE_CLIENT_SECRET=
 FLASK_SECRET_KEY=
 
 # Comma separated list of domains.
-CORS_HOSTS=http://localhost:8081
+CORS_HOSTS=http://localhost:8080
 
 ARANGO_HOST=localhost
 ARANGO_PORT=8529

--- a/.env.default
+++ b/.env.default
@@ -14,6 +14,9 @@ GOOGLE_CLIENT_SECRET=
 # Will be set automatically by the server
 FLASK_SECRET_KEY=
 
+# Comma separated list of domains.
+CORS_HOSTS=http://localhost:8081
+
 ARANGO_HOST=localhost
 ARANGO_PORT=8529
 ARANGO_PROTOCOL=http

--- a/multinet/__init__.py
+++ b/multinet/__init__.py
@@ -24,7 +24,13 @@ sentry_sdk.init(dsn=sentry_dsn, integrations=[FlaskIntegration()])
 def create_app(config: Optional[MutableMapping] = None) -> Flask:
     """Create a Multinet app instance."""
     app = Flask(__name__)
-    CORS(app)
+    CORS(
+        app,
+        resources={
+            "/api/.*": {"origins": "*"},
+            "/user/.*": {"origins": "multinet.app", "supports-credentials": True},
+        },
+    )
     Swagger(app, template_file="swagger/template.yaml")
 
     app.secret_key = flask_secret_key()

--- a/multinet/__init__.py
+++ b/multinet/__init__.py
@@ -21,21 +21,21 @@ sentry_dsn = os.getenv("SENTRY_DSN", default="")
 sentry_sdk.init(dsn=sentry_dsn, integrations=[FlaskIntegration()])
 
 
-def get_cors_hosts() -> List[str]:
+def get_allowed_origins() -> List[str]:
     """Read in comma-separated CORS hosts list from environment."""
-    cors_hosts = os.getenv("CORS_HOSTS", default=None)
-    if cors_hosts is None:
+    allowed_origins = os.getenv("ALLOWED_ORIGINS", default=None)
+    if allowed_origins is None:
         return []
 
-    return cors_hosts.split(",")
+    return allowed_origins.split(",")
 
 
 def create_app(config: Optional[MutableMapping] = None) -> Flask:
     """Create a Multinet app instance."""
     app = Flask(__name__)
 
-    cors_hosts = get_cors_hosts()
-    CORS(app, origins=cors_hosts, supports_credentials=True)
+    allowed_origins = get_allowed_origins()
+    CORS(app, origins=allowed_origins, supports_credentials=True)
     Swagger(app, template_file="swagger/template.yaml")
 
     app.secret_key = flask_secret_key()

--- a/multinet/__init__.py
+++ b/multinet/__init__.py
@@ -22,7 +22,7 @@ sentry_sdk.init(dsn=sentry_dsn, integrations=[FlaskIntegration()])
 
 
 def get_allowed_origins() -> List[str]:
-    """Read in comma-separated CORS hosts list from environment."""
+    """Read in comma-separated list of allowed origins from environment."""
     allowed_origins = os.getenv("ALLOWED_ORIGINS", default=None)
     if allowed_origins is None:
         return []

--- a/multinet/__init__.py
+++ b/multinet/__init__.py
@@ -21,14 +21,25 @@ sentry_dsn = os.getenv("SENTRY_DSN", default="")
 sentry_sdk.init(dsn=sentry_dsn, integrations=[FlaskIntegration()])
 
 
+def get_cors_hosts():
+    """Read in comma-separated CORS hosts list from environment."""
+    cors_hosts = os.getenv("CORS_HOSTS", default=None)
+    if cors_hosts is None:
+        return []
+
+    return cors_hosts.split(",")
+
+
 def create_app(config: Optional[MutableMapping] = None) -> Flask:
     """Create a Multinet app instance."""
     app = Flask(__name__)
+
+    cors_hosts = get_cors_hosts()
     CORS(
         app,
         resources={
-            "/api/.*": {"origins": "*"},
-            "/user/.*": {"origins": "multinet.app", "supports-credentials": True},
+            "/api/.*": {"origins": cors_hosts, "supports_credentials": True},
+            "/user/.*": {"origins": cors_hosts, "supports_credentials": True},
         },
     )
     Swagger(app, template_file="swagger/template.yaml")

--- a/multinet/__init__.py
+++ b/multinet/__init__.py
@@ -7,7 +7,7 @@ from flask_cors import CORS
 from flasgger import Swagger
 from sentry_sdk.integrations.flask import FlaskIntegration
 
-from typing import Optional, MutableMapping, Any, Tuple, Union
+from typing import Optional, MutableMapping, Any, Tuple, Union, List
 
 from multinet import auth
 from multinet.auth import google
@@ -21,7 +21,7 @@ sentry_dsn = os.getenv("SENTRY_DSN", default="")
 sentry_sdk.init(dsn=sentry_dsn, integrations=[FlaskIntegration()])
 
 
-def get_cors_hosts():
+def get_cors_hosts() -> List[str]:
     """Read in comma-separated CORS hosts list from environment."""
     cors_hosts = os.getenv("CORS_HOSTS", default=None)
     if cors_hosts is None:
@@ -35,13 +35,7 @@ def create_app(config: Optional[MutableMapping] = None) -> Flask:
     app = Flask(__name__)
 
     cors_hosts = get_cors_hosts()
-    CORS(
-        app,
-        resources={
-            "/api/.*": {"origins": cors_hosts, "supports_credentials": True},
-            "/user/.*": {"origins": cors_hosts, "supports_credentials": True},
-        },
-    )
+    CORS(app, origins=cors_hosts, supports_credentials=True)
     Swagger(app, template_file="swagger/template.yaml")
 
     app.secret_key = flask_secret_key()

--- a/multinet/__init__.py
+++ b/multinet/__init__.py
@@ -27,7 +27,7 @@ def get_allowed_origins() -> List[str]:
     if allowed_origins is None:
         return []
 
-    return allowed_origins.split(",")
+    return [s.strip() for s in allowed_origins.split(",")]
 
 
 def create_app(config: Optional[MutableMapping] = None) -> Flask:

--- a/mypy_stubs/flask_cors.pyi
+++ b/mypy_stubs/flask_cors.pyi
@@ -1,5 +1,10 @@
 from flask import Flask
 
-from typing import Dict, Any
+from typing import Dict, Any, List, Union
 
-def CORS(app: Flask, resources: Dict[str, Dict[str, Any]]) -> None: ...
+def CORS(
+    app: Flask,
+    origins: Union[str, List[str]],
+    supports_credentials: bool,
+    resources: Dict[str, Dict[str, Any]] = None,
+) -> None: ...

--- a/mypy_stubs/flask_cors.pyi
+++ b/mypy_stubs/flask_cors.pyi
@@ -1,3 +1,5 @@
 from flask import Flask
 
-def CORS(app: Flask) -> None: ...
+from typing import Dict, Any
+
+def CORS(app: Flask, resources: Dict[str, Dict[str, Any]]) -> None: ...


### PR DESCRIPTION
This PR introduces a new environment variable, `ALLOWED_ORIGINS`, to specify the hosts that the server will accept cookies from. By default, in the .env.default file, this is set to `http://localhost:8080` but in production this will be the host at which the main client is served, along with any "affiliate" domains hosting allowed Multinet applications.