### PR TITLE
Fix Swagger UI API failures

### DIFF
--- a/multinet/uploaders/swagger/d3_json.yaml
+++ b/multinet/uploaders/swagger/d3_json.yaml
@@ -5,7 +5,7 @@ consumes:
 
 parameters:
   - $ref: "#/parameters/workspace"
-  - $ref: "#/parameters/table"
+  - $ref: "#/parameters/graph"
   - name: data
     in: body
     description: Raw JSON text

--- a/multinet/uploaders/swagger/nested_json.yaml
+++ b/multinet/uploaders/swagger/nested_json.yaml
@@ -14,35 +14,36 @@ parameters:
       example: |-
         {
           "children": [
-            "children": [
-              {
-                "edge_data": {
-                  "weight": 12.28
-                },
-                "incoming_order": 0,
-                "node_data": {
-                  "name": "a",
-                  "awesomeness": 0.41
-                },
-                "node_fields": [
-                  "name",
-                  "awesomeness"
-                ]
-              }
-            ],
-            "edge_data": {
-              "weight": 3.78
-            },
-            "incoming_order": 3,
-            "node_data": {
-              "name": "c",
-              "awesomeness": 21.438
-            },
-            "node_fields": [
-              "name",
-              "awesomeness"
-            ]
-
+            {
+              "children": [
+                {
+                  "edge_data": {
+                    "weight": 12.28
+                  },
+                  "incoming_order": 0,
+                  "node_data": {
+                    "name": "a",
+                    "awesomeness": 0.41
+                  },
+                  "node_fields": [
+                    "name",
+                    "awesomeness"
+                  ]
+                }
+              ],
+              "edge_data": {
+                "weight": 3.78
+              },
+              "incoming_order": 3,
+              "node_data": {
+                "name": "c",
+                "awesomeness": 21.438
+              },
+              "node_fields": [
+                "name",
+                "awesomeness"
+              ]
+            }
           ],
           "edge_data": {
             "weight": 10.4

--- a/multinet/uploaders/swagger/nested_json.yaml
+++ b/multinet/uploaders/swagger/nested_json.yaml
@@ -5,7 +5,7 @@ consumes:
 
 parameters:
   - $ref: "#/parameters/workspace"
-  - $ref: "#/parameters/table"
+  - $ref: "#/parameters/graph"
   - name: data
     in: body
     description: Raw JSON content of file

--- a/multinet/uploaders/swagger/newick.yaml
+++ b/multinet/uploaders/swagger/newick.yaml
@@ -5,7 +5,7 @@ consumes:
 
 parameters:
   - $ref: "#/parameters/workspace"
-  - $ref: "#/parameters/table"
+  - $ref: "#/parameters/graph"
   - name: data
     in: body
     description: Raw Newick text


### PR DESCRIPTION
We had the wrong datatype listed in the UI for the Newick, nested JSON, and D3 JSON uploaders. 

I also discovered the example data for the nested JSON uploader was invalid JSON; that is fixed on this branch as well.

Thanks to @curtislisle for bringing this to our attention!

Closes #382 