### PR TITLE
Check graph/table existence before reading request body

### DIFF
--- a/multinet/uploaders/csv.py
+++ b/multinet/uploaders/csv.py
@@ -163,6 +163,10 @@ def upload(
     `data` - the CSV data, passed in the request body. If the CSV data contains
              `_from` and `_to` fields, it will be treated as an edge table.
     """
+    space = db.get_workspace_db(workspace)
+    if space.has_collection(table):
+        raise AlreadyExists("table", table)
+
     app.logger.info("Bulk Loading")
 
     # Read the request body into CSV format
@@ -187,13 +191,9 @@ def upload(
 
     # Set the collection, paying attention to whether the data contains
     # _from/_to fields.
-    space = db.get_workspace_db(workspace)
-    if space.has_collection(table):
-        raise AlreadyExists("table", table)
-    else:
-        fieldnames = rows[0].keys()
-        edges = "_from" in fieldnames and "_to" in fieldnames
-        coll = space.create_collection(table, edge=edges)
+    fieldnames = rows[0].keys()
+    edges = "_from" in fieldnames and "_to" in fieldnames
+    coll = space.create_collection(table, edge=edges)
 
     # Insert the data into the collection.
     results = coll.insert_many(rows)

--- a/multinet/uploaders/d3_json.py
+++ b/multinet/uploaders/d3_json.py
@@ -75,6 +75,10 @@ def upload(workspace: str, graph: str) -> Any:
     `data` - the json data, passed in the request body. The json data should contain
     nodes: [] and links: []
     """
+    space = db.get_workspace_db(workspace)
+    if space.has_graph(graph):
+        raise AlreadyExists("graph", graph)
+
     # Get data from the request and load it as json
     body = decode_data(request.data)
     data = json.load(StringIO(body), object_pairs_hook=OrderedDict)
@@ -83,10 +87,6 @@ def upload(workspace: str, graph: str) -> Any:
     errors = validate_d3_json(data)
     if len(errors) > 0:
         raise ValidationFailed(errors)
-
-    space = db.get_workspace_db(workspace)
-    if space.has_graph(graph):
-        raise AlreadyExists("graph", graph)
 
     node_table_name = f"{graph}_nodes"
     edge_table_name = f"{graph}_links"

--- a/multinet/uploaders/nested_json.py
+++ b/multinet/uploaders/nested_json.py
@@ -84,12 +84,12 @@ def upload(workspace: str, graph: str) -> Any:
     `graph` - the target graph.
     `data` - the nested_json data, passed in the request body.
     """
-    # Set up the parameters.
-    data = request.data.decode("utf8")
-
     space = db.get_workspace_db(workspace)
     if space.has_graph(graph):
         raise AlreadyExists("graph", graph)
+
+    # Set up the parameters.
+    data = request.data.decode("utf8")
 
     edgetable_name = f"{graph}_edges"
     int_nodetable_name = f"{graph}_internal_nodes"

--- a/multinet/uploaders/newick.py
+++ b/multinet/uploaders/newick.py
@@ -73,15 +73,13 @@ def upload(workspace: str, graph: str) -> Any:
     """
     app.logger.info("newick tree")
 
-    body = decode_data(request.data)
-
-    tree = newick.loads(body)
-
-    validate_newick(tree)
-
     space = db.get_workspace_db(workspace)
     if space.has_graph(graph):
         raise AlreadyExists("graph", graph)
+
+    body = decode_data(request.data)
+    tree = newick.loads(body)
+    validate_newick(tree)
 
     edgetable_name = f"{graph}_edges"
     nodetable_name = f"{graph}_nodes"


### PR DESCRIPTION
This PR addresses the following issue:

In all of our uploaders, checking that a table/graph already exists is always done after reading in the request body, even though it is independent of the contents, and can be done immediately. This leads to situations where someone finishes uploading a possibly large dataset, only for the server to then respond that the desired table/graph already exists.