### PR TITLE
Remove caching from get_workspace_metadata

### DIFF
--- a/multinet/db.py
+++ b/multinet/db.py
@@ -229,7 +229,7 @@ def get_workspace_metadata(name: str) -> Workspace:
 
     # Find the metadata record for the named workspace. If it's not there,
     # something went very wrong, so bail out.
-    metadata = workspace_mapping(name)
+    metadata = workspace_mapping.__wrapped__(name)
     if metadata is None:
         raise DatabaseCorrupted()
 
@@ -240,10 +240,7 @@ def set_workspace_permissions(
     name: str, permissions: WorkspacePermissions
 ) -> WorkspacePermissions:
     """Update the permissions for a given workspace."""
-    if not workspace_exists(name):
-        raise WorkspaceNotFound(name)
-
-    doc = copy.deepcopy(workspace_mapping(name))
+    doc = copy.deepcopy(get_workspace_metadata(name))
     if doc is None:
         raise DatabaseCorrupted()
 


### PR DESCRIPTION
This fixes a bug recently introduced by #430, which I had not seen during local development, because it only occurs when running the application with multiple workers. This happens when a worker caches the metadata for a workspace, and then someone changes the permissions on the workspace (handled by a different worker). This updates the document revision, but only the worker that handled the permission update gets its cache invalidated, so all other workers still have the old document cached, with the old document revision. This causes a `DocumentRevisionError` when attempting to save the new permissions document.