### PR TITLE
Add CORS function for wildcard origin matching

### DIFF
--- a/multinet/__init__.py
+++ b/multinet/__init__.py
@@ -15,7 +15,7 @@ from multinet import api
 from multinet.db import register_legacy_workspaces
 from multinet import uploaders, downloaders
 from multinet.errors import ServerError
-from multinet.util import load_secret_key
+from multinet.util import load_secret_key, regex_allowed_origins
 
 sentry_dsn = os.getenv("SENTRY_DSN", default="")
 sentry_sdk.init(dsn=sentry_dsn, integrations=[FlaskIntegration()])
@@ -37,8 +37,7 @@ def create_app(config: Optional[MutableMapping] = None) -> Flask:
     if config is not None:
         app.config.update(config)
 
-    allowed_origins = get_allowed_origins()
-    CORS(app, origins=allowed_origins, supports_credentials=True)
+    CORS(app, origins=regex_allowed_origins(get_allowed_origins()))
     Swagger(app, template_file="swagger/template.yaml")
 
     # Set max file upload size to 32 MB

--- a/multinet/__init__.py
+++ b/multinet/__init__.py
@@ -7,7 +7,7 @@ from flask_cors import CORS
 from flasgger import Swagger
 from sentry_sdk.integrations.flask import FlaskIntegration
 
-from typing import Optional, MutableMapping, Any, Tuple, Union, List
+from typing import Optional, MutableMapping, Any, Tuple, Union
 
 from multinet import auth
 from multinet.auth import google
@@ -15,19 +15,10 @@ from multinet import api
 from multinet.db import register_legacy_workspaces
 from multinet import uploaders, downloaders
 from multinet.errors import ServerError
-from multinet.util import load_secret_key, regex_allowed_origins
+from multinet.util import load_secret_key, regex_allowed_origins, get_allowed_origins
 
 sentry_dsn = os.getenv("SENTRY_DSN", default="")
 sentry_sdk.init(dsn=sentry_dsn, integrations=[FlaskIntegration()])
-
-
-def get_allowed_origins() -> List[str]:
-    """Read in comma-separated list of allowed origins from environment."""
-    allowed_origins = os.getenv("ALLOWED_ORIGINS", default=None)
-    if allowed_origins is None:
-        return []
-
-    return [s.strip() for s in allowed_origins.split(",")]
 
 
 def create_app(config: Optional[MutableMapping] = None) -> Flask:

--- a/multinet/util.py
+++ b/multinet/util.py
@@ -8,7 +8,7 @@ from dataclasses import asdict
 from functools import lru_cache
 from uuid import uuid1, uuid4
 from flask import Response, current_app
-from typing import Any, Generator, Dict, List, Iterable
+from typing import Any, Generator, Dict, Set, List, Iterable
 
 from multinet import db
 from multinet.db.models import workspace
@@ -131,6 +131,15 @@ def data_path(file_name: str) -> str:
 def generate_arango_workspace_name() -> str:
     """Generate a string that can be used as an ArangoDB workspace name."""
     return f"w-{uuid1()}"
+
+
+def get_allowed_origins() -> Set[str]:
+    """Read in comma-separated list of allowed origins from environment."""
+    allowed_origins = os.getenv("ALLOWED_ORIGINS", default=None)
+    if allowed_origins is None:
+        return set()
+
+    return {s.strip() for s in allowed_origins.split(",")}
 
 
 def regex_allowed_origins(origins: Iterable[str]) -> List[str]:

--- a/multinet/util.py
+++ b/multinet/util.py
@@ -1,13 +1,14 @@
 """Utility functions."""
 import os
 import json
+import fnmatch
 
 from copy import deepcopy
 from dataclasses import asdict
 from functools import lru_cache
 from uuid import uuid1, uuid4
 from flask import Response, current_app
-from typing import Any, Generator, Dict, Iterable
+from typing import Any, Generator, Dict, List, Iterable
 
 from multinet import db
 from multinet.db.models import workspace
@@ -130,6 +131,11 @@ def data_path(file_name: str) -> str:
 def generate_arango_workspace_name() -> str:
     """Generate a string that can be used as an ArangoDB workspace name."""
     return f"w-{uuid1()}"
+
+
+def regex_allowed_origins(origins: Iterable[str]) -> List[str]:
+    """Return the list of glob-style origin paths as regular expressions."""
+    return [fnmatch.translate(origin) for origin in origins]
 
 
 # Make sure this function is only evaluated once

--- a/mypy_stubs/flask_cors.pyi
+++ b/mypy_stubs/flask_cors.pyi
@@ -4,7 +4,7 @@ from typing import Dict, Any, List, Union
 
 def CORS(
     app: Flask,
-    origins: Union[str, List[str]],
-    supports_credentials: bool,
+    origins: Union[str, List[str]] = "*",
+    supports_credentials: bool = False,
     resources: Dict[str, Dict[str, Any]] = None,
 ) -> None: ...

--- a/test/test_cors.py
+++ b/test/test_cors.py
@@ -1,0 +1,35 @@
+"""Test that application CORS behaves as we expect."""
+import pytest
+from flask_cors import CORS
+from multinet.util import regex_allowed_origins
+
+
+@pytest.mark.parametrize(
+    "allowed,origin,expected",
+    [
+        ({"*"}, "thing.com", "thing.com"),
+        ({"*", "thing.com"}, "thing.com", "thing.com"),
+        ({"thing.com"}, "thing.com", "thing.com"),
+        ({"thing.com"}, "notthing.com", None),
+        ({"thing.com"}, "subdomain.thing.com", None),
+        ({"*.thing.com"}, "subdomain.thing.com", "subdomain.thing.com"),
+        (
+            {"fixed*more-fixed.thing.com"},
+            "fixed-something-more-fixed.thing.com",
+            "fixed-something-more-fixed.thing.com",
+        ),
+        ({"fixed*more-fixed.thing.com"}, "other-fixed*other.thing.com", None),
+        ({"anything", "thing.com", "thing", "*thing", "thing*"}, "anything.com", None),
+        ({"*thing*"}, "anything.com", "anything.com"),
+    ],
+)
+def test_cors_matching(app, server, managed_workspace, allowed, origin, expected):
+    """Test the `require_reader` decorator."""
+    # Instruct app to use new allowed origins
+    CORS(app, origins=regex_allowed_origins(allowed))
+
+    # Make request and check header
+    resp = server.get(
+        f"/api/workspaces/{managed_workspace}", headers={"Origin": origin}
+    )
+    assert resp.headers.get("Access-Control-Allow-Origin") == expected


### PR DESCRIPTION
Fixes #384

This adds the ability for allowed origins to be specified with wildcards. This would allow, for example, a specific subdomain of a domain to be allowed through CORS, without needing to allow the entire site, or any unwanted similar subdomains of that site. One of the main use cases here is to allow for Netlify deploy previews to access the testing application, without the need for the testing app to specify allowed origins of `*`, which is what's currently done.

~~Notably, this removes the use of `flask-cors`, replacing it entirely with our custom CORS handling. I originally was going to let this new handling and `flask-cors` co-exist, but given that `flask-cors` runs after this new function, and that my function performs a superset of functionality that `flask-cors` does, keeping it was redundant.~~

I've re-implemented this in flask-cors, since it supports it, and is a clean change.