### PR TITLE
Misc changes to `User`

### DIFF
--- a/multinet/auth/google.py
+++ b/multinet/auth/google.py
@@ -133,8 +133,6 @@ def authorized(state: str, code: str) -> ResponseWrapper:
         user = User.from_dict(new_user_data)
 
     cookie = user.get_session()
-    user.save()
-
     return_url = session.pop("return_url", default_return_url())
     resp = make_response(redirect(ensure_external_url(return_url)))
     session[MULTINET_COOKIE] = cookie

--- a/multinet/db/models/user.py
+++ b/multinet/db/models/user.py
@@ -94,9 +94,7 @@ class User:
     def register(*args: Any, **kwargs: Any) -> User:
         """Register and return a user with the passed info."""
         user = User(*args, **kwargs)
-
-        user.multinet = MultinetInfo(session=generate_user_session())
-        user.save()
+        user.ensure_session()
 
         return user
 
@@ -167,14 +165,23 @@ class User:
         if doc:
             coll.delete(doc["_id"])
 
-    def get_session(self) -> str:
-        """Return the login session of a user, creating it if it doesn't exist."""
+    def ensure_session(self) -> None:
+        """Ensure that this user has a valid session."""
         if self.multinet is None:
             self.multinet = MultinetInfo(session=generate_user_session())
 
         if self.multinet.session is None:
             self.multinet.session = generate_user_session()
 
+        self.save()
+
+    def get_session(self) -> str:
+        """Return the login session of a user."""
+        self.ensure_session()
+
+        # Asserts needed for mypy
+        assert self.multinet is not None
+        assert self.multinet.session is not None
         return self.multinet.session
 
     def set_session(self, session: str) -> None:


### PR DESCRIPTION
This PR just re-organizes some code that I noticed while looking around the code base. This shouldn't change any behavior, just code organization/clarity.

- Add `ensure_session`, to create a user session if needed
- Call `ensure_session` from `get_session`
- Call `ensure_session` from `User.register`