### PR TITLE
Fix cookie use

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,6 +46,7 @@ jobs:
         if: steps.multinet-cache.outputs.cache-hit != 'true'
         run: pipenv install --dev --deploy
 
+      - run: which pipenv
       - run: pipenv run lint
       - run: pipenv run format
       - run: pipenv run typecheck

--- a/multinet/auth/__init__.py
+++ b/multinet/auth/__init__.py
@@ -1,15 +1,15 @@
 """Authorization types."""
 import json
 from flasgger import swag_from
-from flask import make_response, session
+from flask import make_response, request, Response
 from flask.blueprints import Blueprint
 from werkzeug.wrappers import Response as ResponseWrapper
 from webargs import fields
 from webargs.flaskparser import use_kwargs
 
-from multinet.db.models.user import MULTINET_COOKIE, User
+from multinet.db.models.user import User
 from multinet.util import stream
-from multinet.auth.util import require_login
+from multinet.auth.util import require_login, LOGIN_TOKEN_COOKIE
 
 bp = Blueprint("user", "user")
 
@@ -18,16 +18,15 @@ bp = Blueprint("user", "user")
 @swag_from("swagger/user/info.yaml")
 def user_info() -> ResponseWrapper:
     """Return the filtered user object."""
+    logged_out: Response = make_response(json.dumps(None), 200)
 
-    logged_out = make_response(json.dumps(None), 200)
-
-    cookie = session.get(MULTINET_COOKIE)
+    cookie = request.cookies.get(LOGIN_TOKEN_COOKIE)
     if cookie is None:
         return logged_out
 
     user = User.from_session(cookie)
     if user is None:
-        session.pop(MULTINET_COOKIE, None)
+        logged_out.set_cookie(LOGIN_TOKEN_COOKIE, "", expires=0)
         return logged_out
 
     return make_response(user.asdict())
@@ -38,8 +37,7 @@ def user_info() -> ResponseWrapper:
 def logout() -> ResponseWrapper:
     """Return the filtered user object."""
 
-    # Instruct the browser to delete its session cookie, if it exists.
-    cookie = session.pop(MULTINET_COOKIE, None)
+    cookie = request.cookies.get(LOGIN_TOKEN_COOKIE)
     if cookie is not None:
         # Load the user model and invalidate its session.
 
@@ -47,7 +45,11 @@ def logout() -> ResponseWrapper:
         if user is not None:
             user.delete_session()
 
-    return make_response("", 200)
+    # Instruct the browser to delete its session cookie, if it exists.
+    resp: Response = make_response("", 200)
+    resp.set_cookie(LOGIN_TOKEN_COOKIE, "", expires=0)
+
+    return resp
 
 
 @bp.route("/search", methods=["GET"])

--- a/multinet/auth/__init__.py
+++ b/multinet/auth/__init__.py
@@ -20,11 +20,11 @@ def user_info() -> ResponseWrapper:
     """Return the filtered user object."""
     logged_out: Response = make_response(json.dumps(None), 200)
 
-    cookie = request.cookies.get(LOGIN_TOKEN_COOKIE)
-    if cookie is None:
+    login_token = request.cookies.get(LOGIN_TOKEN_COOKIE)
+    if login_token is None:
         return logged_out
 
-    user = User.from_session(cookie)
+    user = User.from_session(login_token)
     if user is None:
         logged_out.set_cookie(LOGIN_TOKEN_COOKIE, "", expires=0)
         return logged_out
@@ -37,11 +37,11 @@ def user_info() -> ResponseWrapper:
 def logout() -> ResponseWrapper:
     """Return the filtered user object."""
 
-    cookie = request.cookies.get(LOGIN_TOKEN_COOKIE)
-    if cookie is not None:
+    login_token = request.cookies.get(LOGIN_TOKEN_COOKIE)
+    if login_token is not None:
         # Load the user model and invalidate its session.
 
-        user = User.from_session(cookie)
+        user = User.from_session(login_token)
         if user is not None:
             user.delete_session()
 

--- a/multinet/auth/google.py
+++ b/multinet/auth/google.py
@@ -142,7 +142,7 @@ def authorized(state: str, code: str) -> ResponseWrapper:
         new_user_data = {**User.asdict(existing_user), **rawinfo.__dict__}
         user = User.from_dict(new_user_data)
 
-    cookie = user.get_session()
+    login_token = user.get_session()
     user.save()
 
     return_url = session.pop("return_url", default_return_url())
@@ -152,7 +152,7 @@ def authorized(state: str, code: str) -> ResponseWrapper:
     development = current_app.config.get("ENV") == "development"
     resp.set_cookie(
         LOGIN_TOKEN_COOKIE,
-        value=cookie,
+        value=login_token,
         secure=True if not development else False,
         samesite="None" if not development else None,
         httponly=True,

--- a/multinet/auth/util.py
+++ b/multinet/auth/util.py
@@ -7,6 +7,8 @@ from multinet.errors import Unauthorized
 from multinet.db.models.workspace import Workspace
 from multinet.db.models.user import current_user, User
 
+LOGIN_TOKEN_COOKIE = "LOGIN_TOKEN"
+
 
 # NOTE: unfortunately, it is difficult to write a type signature for this
 # decorator. I've opened an issue to ask about this here:

--- a/multinet/db/models/user.py
+++ b/multinet/db/models/user.py
@@ -36,11 +36,11 @@ class UserInfo:
 
 def current_user() -> Optional[User]:
     """Return the logged in user (if any) from the current session."""
-    cookie = request.cookies.get(auth.util.LOGIN_TOKEN_COOKIE)
-    if cookie is None:
+    login_token = request.cookies.get(auth.util.LOGIN_TOKEN_COOKIE)
+    if login_token is None:
         return None
 
-    return User.from_session(cookie)
+    return User.from_session(login_token)
 
 
 def generate_user_session() -> str:

--- a/multinet/db/models/user.py
+++ b/multinet/db/models/user.py
@@ -6,14 +6,13 @@ from dataclasses import dataclass
 from uuid import uuid4
 from copy import copy
 from dacite import from_dict
-from flask import session as flask_session
+from flask import request
 from arango.cursor import Cursor
 
+from multinet import auth
 from multinet.db import user_collection, system_db, _run_aql_query
 
 from typing import Optional, Dict, Generator, Any
-
-MULTINET_COOKIE = "multinet-token"
 
 
 @dataclass
@@ -37,7 +36,7 @@ class UserInfo:
 
 def current_user() -> Optional[User]:
     """Return the logged in user (if any) from the current session."""
-    cookie = flask_session.get(MULTINET_COOKIE)
+    cookie = request.cookies.get(auth.util.LOGIN_TOKEN_COOKIE)
     if cookie is None:
         return None
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -4,25 +4,26 @@ import pytest
 from uuid import uuid4
 from contextlib import contextmanager
 from pathlib import Path
+from flask.testing import FlaskClient
 
 from multinet import create_app
 from multinet.db.models.workspace import Workspace
-from multinet.db.models.user import User, MULTINET_COOKIE
+from multinet.db.models.user import User
+from multinet.auth.util import LOGIN_TOKEN_COOKIE
 
 from typing import Generator, Tuple
 
 
 @contextmanager
-def login(user: User, server) -> Generator[None, None, None]:
+def login(user: User, server: FlaskClient) -> Generator[None, None, None]:
     """Perform server actions under a user login."""
 
-    with server.session_transaction() as session:
-        session[MULTINET_COOKIE] = user.multinet.session
+    # This function technically requires a domain, so we set it to empty string
+    server.set_cookie("", LOGIN_TOKEN_COOKIE, user.multinet.session)
 
     yield None
 
-    with server.session_transaction() as session:
-        del session[MULTINET_COOKIE]
+    server.delete_cookie("", LOGIN_TOKEN_COOKIE)
 
 
 @pytest.fixture


### PR DESCRIPTION
Fixes #468.

This changes our handling of cookies from using Flask's `session` object, to directly handling cookies. This is to allow the setting of the `SameSite` and `Secure` cookie options mentioned in the linked issue. Notably, Flask's `session` is still used in one place: the Google login flow. This is only to temporarily store the `return_url` parameter, so that once login is finished, the api can redirect the browser to where it came from. There is no security risk here, and it's actually a pretty nice way to store this temporary data.

This PR also renames some variables, to make it more clear what's going on.

Starting this as a draft PR so I can test out it's functionality on a live site (using https).