### PR TITLE
Return to using cookies for login

### DIFF
--- a/multinet/__init__.py
+++ b/multinet/__init__.py
@@ -28,7 +28,11 @@ def create_app(config: Optional[MutableMapping] = None) -> Flask:
     if config is not None:
         app.config.update(config)
 
-    CORS(app, origins=regex_allowed_origins(get_allowed_origins()))
+    CORS(
+        app,
+        origins=regex_allowed_origins(get_allowed_origins()),
+        supports_credentials=True,
+    )
     Swagger(app, template_file="swagger/template.yaml")
 
     # Set max file upload size to 32 MB

--- a/multinet/auth/__init__.py
+++ b/multinet/auth/__init__.py
@@ -1,7 +1,7 @@
 """Authorization types."""
 import json
 from flasgger import swag_from
-from flask import make_response
+from flask import make_response, Response
 from flask.blueprints import Blueprint
 from werkzeug.wrappers import Response as ResponseWrapper
 from webargs import fields
@@ -19,7 +19,7 @@ bp = Blueprint("user", "user")
 def user_info() -> ResponseWrapper:
     """Return the filtered user object."""
 
-    logged_out: ResponseWrapper = make_response(json.dumps(None), 200)
+    logged_out: Response = make_response(json.dumps(None), 200)
     logged_out.delete_cookie(MULTINET_LOGIN_TOKEN)
 
     token = current_login_token()
@@ -46,7 +46,7 @@ def logout() -> ResponseWrapper:
         if user is not None:
             user.delete_session()
 
-    resp: ResponseWrapper = make_response("", 200)
+    resp: Response = make_response("", 200)
     resp.delete_cookie(MULTINET_LOGIN_TOKEN)
     return resp
 

--- a/multinet/auth/__init__.py
+++ b/multinet/auth/__init__.py
@@ -9,7 +9,7 @@ from webargs.flaskparser import use_kwargs
 
 from multinet.db.models.user import User
 from multinet.util import stream
-from multinet.auth.util import require_login, current_login_token
+from multinet.auth.util import require_login, current_login_token, MULTINET_LOGIN_TOKEN
 
 bp = Blueprint("user", "user")
 
@@ -19,7 +19,8 @@ bp = Blueprint("user", "user")
 def user_info() -> ResponseWrapper:
     """Return the filtered user object."""
 
-    logged_out = make_response(json.dumps(None), 200)
+    logged_out: ResponseWrapper = make_response(json.dumps(None), 200)
+    logged_out.delete_cookie(MULTINET_LOGIN_TOKEN)
 
     token = current_login_token()
     if token is None:
@@ -45,7 +46,9 @@ def logout() -> ResponseWrapper:
         if user is not None:
             user.delete_session()
 
-    return make_response("", 200)
+    resp: ResponseWrapper = make_response("", 200)
+    resp.delete_cookie(MULTINET_LOGIN_TOKEN)
+    return resp
 
 
 @bp.route("/search", methods=["GET"])

--- a/multinet/auth/google.py
+++ b/multinet/auth/google.py
@@ -6,7 +6,7 @@ import os
 
 from dacite import from_dict
 from flasgger import swag_from
-from flask import Flask, redirect, request, session, make_response, url_for
+from flask import Flask, redirect, request, Response, session, make_response, url_for
 from werkzeug.wrappers import Response as ResponseWrapper
 from flask.blueprints import Blueprint
 from authlib.integrations.flask_client import OAuth
@@ -139,7 +139,7 @@ def authorized(state: str, code: str) -> ResponseWrapper:
         user.save()
 
     return_url = session.pop("return_url", default_return_url())
-    resp: ResponseWrapper = make_response(redirect(ensure_external_url(return_url)))
+    resp: Response = make_response(redirect(ensure_external_url(return_url)))
 
     encoded_login_token = encode_auth_token(create_login_token(user.get_session()))
     resp.set_cookie(MULTINET_LOGIN_TOKEN, encoded_login_token)

--- a/multinet/auth/google.py
+++ b/multinet/auth/google.py
@@ -6,7 +6,16 @@ import os
 
 from dacite import from_dict
 from flasgger import swag_from
-from flask import Flask, redirect, request, Response, session, make_response, url_for
+from flask import (
+    Flask,
+    current_app,
+    redirect,
+    request,
+    Response,
+    session,
+    make_response,
+    url_for,
+)
 from werkzeug.wrappers import Response as ResponseWrapper
 from flask.blueprints import Blueprint
 from authlib.integrations.flask_client import OAuth
@@ -142,6 +151,15 @@ def authorized(state: str, code: str) -> ResponseWrapper:
     resp: Response = make_response(redirect(ensure_external_url(return_url)))
 
     encoded_login_token = encode_auth_token(create_login_token(user.get_session()))
-    resp.set_cookie(MULTINET_LOGIN_TOKEN, encoded_login_token)
+
+    # If running in development, don't set secure and samesite cookie attributes
+    development = current_app.config.get("ENV") == "development"
+    resp.set_cookie(
+        MULTINET_LOGIN_TOKEN,
+        value=encoded_login_token,
+        secure=True if not development else False,
+        samesite="None" if not development else None,
+        httponly=True,
+    )
 
     return resp

--- a/test/test_permissions.py
+++ b/test/test_permissions.py
@@ -10,3 +10,15 @@ def test_require_reader(server, managed_workspace, managed_user):
 
     assert resp.status_code == 200
     assert resp.json["owner"]["sub"] == managed_user.sub
+
+
+# Corresponding login test is in test_meta
+def test_logout(server, managed_workspace, managed_user):
+    """Test that logout works properly."""
+
+    with conftest.login(managed_user, server):
+        resp = server.get(f"/api/user/logout")
+        assert resp.status_code == 200
+
+        resp = server.get(f"/api/workspaces/{managed_workspace.name}/permissions")
+        assert resp.status_code == 401


### PR DESCRIPTION
Partly reverts #472. Notably, JWTs are still used, as I believe they're a good method for issuing logins.