### PR TITLE
Introduce Table Metadata

### DIFF
--- a/multinet/api.py
+++ b/multinet/api.py
@@ -5,7 +5,7 @@ from webargs import fields
 from webargs.flaskparser import use_kwargs
 
 from typing import Any, Optional
-from multinet.types import EdgeDirection, TableType
+from multinet.types import EdgeDirection, UnionTableType
 from multinet.auth.util import (
     require_login,
     require_reader,
@@ -73,7 +73,9 @@ def set_workspace_permissions(workspace: str) -> Any:
 @require_reader
 @use_kwargs({"type": fields.Str()})
 @swag_from("swagger/workspace_tables.yaml")
-def get_workspace_tables(workspace: str, type: TableType = "all") -> Any:  # noqa: A002
+def get_workspace_tables(
+    workspace: str, type: UnionTableType = "all"  # noqa: A002
+) -> Any:
     """Retrieve the tables of a single workspace."""
     tables = Workspace(workspace).tables(type)
     return util.stream(tables)
@@ -98,6 +100,23 @@ def create_aql_table(workspace: str, table: str) -> Any:
 def get_table_rows(workspace: str, table: str, offset: int = 0, limit: int = 30) -> Any:
     """Retrieve the rows and headers of a table."""
     return Workspace(workspace).table(table).rows(offset, limit)
+
+
+@bp.route("/workspaces/<workspace>/tables/<table>/metadata", methods=["GET"])
+@require_reader
+@swag_from("swagger/get_metadata.yaml")
+def get_table_metadata(workspace: str, table: str) -> Any:
+    """Retrieve the metadata of a table, if it exists."""
+    metadata = Workspace(workspace).table(table).get_metadata()
+    return "" if metadata is None else metadata.dict()
+
+
+@bp.route("/workspaces/<workspace>/tables/<table>/metadata", methods=["PUT"])
+@require_reader
+@swag_from("swagger/set_metadata.yaml")
+def set_table_metadata(workspace: str, table: str) -> Any:
+    """Retrieve the rows and headers of a table."""
+    return Workspace(workspace).table(table).set_metadata(request.json).dict()
 
 
 @bp.route("/workspaces/<workspace>/graphs", methods=["GET"])

--- a/multinet/errors.py
+++ b/multinet/errors.py
@@ -1,5 +1,5 @@
 """Exception objects representing Multinet-specific HTTP error conditions."""
-from typing import Tuple, Any, Union, List, Sequence
+from typing import Tuple, Any, Union, Dict, List, Sequence
 from typing_extensions import TypedDict
 
 from multinet.validation import ValidationFailure
@@ -158,6 +158,18 @@ class MalformedRequestBody(ServerError):
     def flask_response(self) -> FlaskTuple:
         """Generate a 400 error."""
         return (self.body, "400 Malformed Request Body")
+
+
+class InvalidMetadata(ServerError):
+    """Exception for specifying invalid metadata."""
+
+    def __init__(self, metadata: Dict):
+        """Initialize the exception."""
+        self.metadata = metadata
+
+    def flask_response(self) -> FlaskTuple:
+        """Generate a 400 error."""
+        return (self.metadata, "400 Invalid Metadata")
 
 
 class RequiredParamsMissing(ServerError):

--- a/multinet/swagger/get_metadata.yaml
+++ b/multinet/swagger/get_metadata.yaml
@@ -1,0 +1,20 @@
+Retrieve the metadata of a table.
+---
+parameters:
+  - $ref: "#/parameters/workspace"
+  - $ref: "#/parameters/table"
+
+responses:
+  200:
+    description: The permissions for the given workspace
+    schema:
+      $ref: "#/definitions/workspace_permissions"
+
+  404:
+    description: Specified workspace or table could not be found
+    schema:
+      type: string
+      example: workspace_or_table_that_doesnt_exist
+
+tags:
+  - table

--- a/multinet/swagger/set_metadata.yaml
+++ b/multinet/swagger/set_metadata.yaml
@@ -1,0 +1,35 @@
+Set the metadata of a table.
+---
+parameters:
+  - $ref: "#/parameters/workspace"
+  - $ref: "#/parameters/table"
+  - name: metadata
+    in: body
+    description: The metadata to set (overwrites existing data)
+    required: true
+    schema:
+      type: object
+      example:
+        columns:
+          - key: test
+            type: label
+
+          - key: length
+            type: number
+
+
+
+responses:
+  200:
+    description: The permissions for the given workspace
+    schema:
+      $ref: "#/definitions/workspace_permissions"
+
+  404:
+    description: Specified workspace or table could not be found
+    schema:
+      type: string
+      example: workspace_or_table_that_doesnt_exist
+
+tags:
+  - table

--- a/multinet/types.py
+++ b/multinet/types.py
@@ -1,9 +1,63 @@
 """Custom types for Multinet codebase."""
-from typing import Dict, Set
+from pydantic import BaseModel, Field
+from typing import List, Dict, Set, Optional, Any
 from typing_extensions import Literal, TypedDict
 
 EdgeDirection = Literal["all", "incoming", "outgoing"]
-TableType = Literal["all", "node", "edge"]
+
+TableType = Literal["node", "edge"]
+UnionTableType = Literal["all", TableType]
+ColumnType = Literal["label", "boolean", "category", "number", "date"]
+
+
+class ColumnMetadata(BaseModel):
+    """Metadata for a table column."""
+
+    key: str
+    type: ColumnType
+
+
+class TableMetadata(BaseModel):
+    """Metadata for a table."""
+
+    columns: List[ColumnMetadata] = Field(default_factory=list)
+
+
+class GraphMetadata(BaseModel):
+    """Metadata for a graph."""
+
+
+class EntityMetadata(BaseModel):
+    """Metadata for a table or graph."""
+
+    item_id: str
+    table: Optional[TableMetadata]
+    graph: Optional[GraphMetadata]
+
+
+class ArangoEntityDocument(EntityMetadata):
+    """An entity metadata document with arangodb metadata."""
+
+    def dict(self, **kwargs: Any) -> Dict:  # noqa: A003
+        """
+        Overload existing dict function to use alias for dict serialization.
+
+        Variable names with leading underscores aren't treated normally, and need to be
+        aliased to be properly specified. Since pydantic doesn't serialize with alias
+        names by default, this overload is needed.
+        """
+
+        kwargs["by_alias"] = True
+        return super().dict(**kwargs)
+
+    id: str = Field(alias="_id")
+    key: str = Field(alias="_key")
+    rev: str = Field(alias="_rev")
+
+    class Config:
+        """Model config."""
+
+        allow_population_by_field_name = True
 
 
 class EdgeTableProperties(TypedDict):

--- a/multinet/uploaders/csv.py
+++ b/multinet/uploaders/csv.py
@@ -1,5 +1,6 @@
 """Multinet uploader for CSV files."""
 import csv
+import json
 from flasgger import swag_from
 from io import StringIO
 
@@ -16,7 +17,7 @@ from webargs import fields as webarg_fields
 from webargs.flaskparser import use_kwargs
 
 # Import types
-from typing import Any, List, Dict
+from typing import Any, List, Dict, Optional
 
 
 bp = Blueprint("csv", __name__)
@@ -47,12 +48,17 @@ def set_table_key(rows: List[Dict[str, str]], key: str) -> List[Dict[str, str]]:
     {
         "key": webarg_fields.Str(location="query"),
         "overwrite": webarg_fields.Bool(location="query"),
+        "metadata": webarg_fields.Str(location="query"),
     }
 )
 @require_writer
 @swag_from("swagger/csv.yaml")
 def upload(
-    workspace: str, table: str, key: str = "_key", overwrite: bool = False
+    workspace: str,
+    table: str,
+    key: str = "_key",
+    overwrite: bool = False,
+    metadata: Optional[str] = None,
 ) -> Any:
     """
     Store a CSV file into the database as a node or edge table.
@@ -95,6 +101,10 @@ def upload(
 
     # Create table and insert the data
     loaded_table = loaded_workspace.create_table(table, edges)
+
+    if metadata:
+        loaded_table.set_metadata(json.loads(metadata))
+
     results = loaded_table.insert(rows)
 
     return {"count": len(results)}

--- a/multinet/uploaders/swagger/csv.yaml
+++ b/multinet/uploaders/swagger/csv.yaml
@@ -34,6 +34,21 @@ parameters:
     schema:
       type: boolean
       default: false
+  -
+    name: metadata
+    in: query
+    description: Metadata to set for the table
+    schema:
+      type: object
+      example:
+        columns:
+          -
+            key: city
+            type: label
+          -
+            key: size
+            type: number
+
 
 responses:
   200:

--- a/test/test_metadata.py
+++ b/test/test_metadata.py
@@ -1,0 +1,70 @@
+"""Testing operations on metadata."""
+import conftest
+import pytest
+import json
+
+
+def test_set_valid_table_metadata(populated_workspace, managed_user, server):
+    """Test that setting valid metadata succeeds."""
+    workspace, _, node_table, _ = populated_workspace
+    metadata = {"columns": [{"key": "test", "type": "label"}]}
+
+    with conftest.login(managed_user, server):
+        resp = server.put(
+            f"/api/workspaces/{workspace.name}/tables/{node_table}/metadata",
+            json=metadata,
+        )
+
+        assert resp.status_code == 200
+        assert resp.json["table"] == metadata
+
+
+@pytest.mark.parametrize(
+    "metadata, expected",
+    [
+        ({"columns": [{"key": "test", "type": "invalid"}]}, 400),
+        ({"columns": [{"foo": "bar"}]}, 400),
+        ({"foo": "bar"}, 200),
+    ],
+)
+def test_set_invalid_table_metadata(
+    populated_workspace, managed_user, server, metadata, expected
+):
+    """Test that setting invalid metadata fails."""
+    workspace, _, node_table, _ = populated_workspace
+
+    with conftest.login(managed_user, server):
+        resp = server.put(
+            f"/api/workspaces/{workspace.name}/tables/{node_table}/metadata",
+            json=metadata,
+        )
+        assert resp.status_code == expected
+
+
+# NOTE: Including metadata in CSV uploads will likely be removed in a future API change
+def test_csv_upload_with_metadata(
+    managed_workspace, managed_user, server, data_directory
+):
+    """Test that uploading a CSV file with metadata succeeds."""
+
+    table_name = "test"
+    metadata = {"columns": [{"key": "test", "type": "label"}]}
+
+    with open(data_directory / "membership_with_keys.csv") as csv_file:
+        request_body = csv_file.read()
+
+    with conftest.login(managed_user, server):
+        resp = server.post(
+            f"/api/csv/{managed_workspace.name}/{table_name}",
+            data=request_body,
+            query_string={"metadata": json.dumps(metadata)},
+        )
+
+        assert resp.status_code == 200
+
+        resp = server.get(
+            f"/api/workspaces/{managed_workspace.name}/tables/{table_name}/metadata"
+        )
+
+        assert resp.status_code == 200
+        assert resp.json["table"] == metadata


### PR DESCRIPTION
Closes #482 

This is a basic first approach to table metadata. In this approach, table metadata is passed as a query string argument to the CSV upload endpoint. This is not ideal, and is only in place until [this](https://github.com/multinet-app/multinet-rfcs/issues/20) issue is addressed. 

One of the side effects is that this PR slightly changes how tables are created. Now, the entire workspace instance is passed into the `Table` constructor, which the constructor selects things from. This was mainly needed for referring to the workspace metadata collection. I actually think this approach is cleaner overall.