### PR TITLE
Upgrade to ArangoDB 3.5 in docker-compose setup

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   arangodb:
-    image: arangodb/arangodb:3.4.3
+    image: arangodb/arangodb:3.5.6
     ports:
       - "${ARANGO_PORT:-8529}:8529"
     environment:


### PR DESCRIPTION
This brings ArangoDB used in dev to the same minor version as that used
in deployment. In particular, this upgrade allows use of the AQL `PRUNE`
keyword.